### PR TITLE
Bug fixes handling options/filters in S3Vectors

### DIFF
--- a/app/inspector/http/www/record.go
+++ b/app/inspector/http/www/record.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sfomuseum/go-embeddingsdb"
 	inspector_http "github.com/sfomuseum/go-embeddingsdb/app/inspector/http"
 	"github.com/sfomuseum/go-embeddingsdb/client"
+	"github.com/sfomuseum/go-embeddingsdb/options"
 )
 
 type RecordHandlerOptions struct {
@@ -86,6 +87,8 @@ func RecordHandler(opts *RecordHandlerOptions) (http.Handler, error) {
 			},
 		}
 
+		custom_opts := make([]options.Option, 0)
+
 		similar_provider, err := sanitize.GetString(req, "similar-provider")
 
 		if err != nil {
@@ -102,7 +105,10 @@ func RecordHandler(opts *RecordHandlerOptions) (http.Handler, error) {
 				return
 			}
 
+			// DEPRECATED
 			similar_req.SimilarProvider = &similar_provider
+
+			custom_opts = append(custom_opts, options.NewSimilarProviderOption(similar_provider))
 		}
 
 		max_dist := float32(0.0)
@@ -126,10 +132,14 @@ func RecordHandler(opts *RecordHandlerOptions) (http.Handler, error) {
 			}
 
 			max_dist := float32(max64)
+
+			// DEPRECATED
 			similar_req.MaxDistance = &max_dist
+
+			custom_opts = append(custom_opts, options.NewMaxDistanceOption(max_dist))
 		}
 
-		similar, err := opts.Client.SimilarRecords(ctx, similar_req)
+		similar, err := opts.Client.SimilarRecords(ctx, similar_req, custom_opts...)
 
 		if err != nil {
 			logger.Error("Failed to retrieve similar records", "error", err)

--- a/client/list.go
+++ b/client/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aaronland/go-pagination/cursor"
 	"github.com/sfomuseum/go-embeddingsdb"
 	"github.com/sfomuseum/go-embeddingsdb/database"
+	"github.com/sfomuseum/go-embeddingsdb/options"
 )
 
 // ListRecordOptions defines configuration options for calling the `ListRecords` method.
@@ -39,7 +40,7 @@ func DefaultListRecordsOptions() *ListRecordsOptions {
 
 // ListRecords returns an [iter.Seq2[*embeddingsdb.Record, error]] iterator for listing all the records in
 // an `embeddingsdb` database. It handles all the pagination requirements derived from 'opts'.
-func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.Seq2[*embeddingsdb.Record, error] {
+func ListRecords(ctx context.Context, cl Client, list_opts *ListRecordsOptions, opts ...options.Option) iter.Seq2[*embeddingsdb.Record, error] {
 
 	return func(yield func(*embeddingsdb.Record, error) bool) {
 
@@ -62,14 +63,14 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 				return
 			}
 
-			pg_opts.PerPage(opts.PerPage)
+			pg_opts.PerPage(list_opts.PerPage)
 
 			page := int64(1)
 
 			for {
 
 				logger.Debug("Query records", "pointer", pg_opts.Pointer())
-				records, pg_rsp, err := cl.ListRecords(ctx, pg_opts)
+				records, pg_rsp, err := cl.ListRecords(ctx, pg_opts, opts...)
 
 				if err != nil {
 					logger.Error("Failed to list records", "pointer", pg_opts.Pointer(), "error", err)
@@ -77,8 +78,8 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 					return
 				}
 
-				if page < opts.StartPage {
-					logger.Debug("Results before start page, skipping", "start", opts.StartPage, "page", page)
+				if page < list_opts.StartPage {
+					logger.Debug("Results before start page, skipping", "start", list_opts.StartPage, "page", page)
 				} else {
 					for _, r := range records {
 
@@ -98,8 +99,8 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 					break
 				}
 
-				if opts.EndPage != -1 && page > opts.EndPage {
-					logger.Debug("Arrived at requested end page", "end page", opts.EndPage, "page", page)
+				if list_opts.EndPage != -1 && page > list_opts.EndPage {
+					logger.Debug("Arrived at requested end page", "end page", list_opts.EndPage, "page", page)
 					break
 				}
 
@@ -110,7 +111,7 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 
 		case database.CountablePaginationType:
 
-			current_page := opts.StartPage
+			current_page := list_opts.StartPage
 			pages := int64(0)
 
 			pg_opts, err := countable.NewCountableOptions()
@@ -120,12 +121,12 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 				return
 			}
 
-			pg_opts.PerPage(opts.PerPage)
+			pg_opts.PerPage(list_opts.PerPage)
 
 			logger := slog.Default()
-			logger = logger.With("start page", opts.StartPage)
-			logger = logger.With("end page", opts.EndPage)
-			logger = logger.With("per page", opts.PerPage)
+			logger = logger.With("start page", list_opts.StartPage)
+			logger = logger.With("end page", list_opts.EndPage)
+			logger = logger.With("per page", list_opts.PerPage)
 
 			logger.Debug("Start pagination")
 
@@ -134,7 +135,7 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 				pg_opts.Pointer(current_page)
 
 				logger.Debug("Query records", "page", current_page, "total page count", pages)
-				records, pg_rsp, err := cl.ListRecords(ctx, pg_opts)
+				records, pg_rsp, err := cl.ListRecords(ctx, pg_opts, opts...)
 
 				if err != nil {
 					logger.Error("Failed to list records", "page", current_page, "error", err)
@@ -155,7 +156,7 @@ func ListRecords(ctx context.Context, cl Client, opts *ListRecordsOptions) iter.
 					pages = pg_rsp.Pages()
 				}
 
-				if opts.EndPage != -1 && current_page >= opts.EndPage {
+				if list_opts.EndPage != -1 && current_page >= list_opts.EndPage {
 					logger.Debug("End page reached", "page", current_page)
 					break
 				}

--- a/database/s3vectors.go
+++ b/database/s3vectors.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	// "encoding/json"
+
 	"github.com/aaronland/go-aws/v3/auth"
 	"github.com/aaronland/go-pagination"
 	"github.com/aaronland/go-pagination/cursor"
@@ -360,8 +362,9 @@ func (db *S3VectorsDatabase) SimilarRecords(ctx context.Context, req *embeddings
 		// Filter is set below
 	}
 
-	has_filter := false
-	filter := make(map[string]interface{})
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-metadata-filtering.html
+
+	filters := make([]map[string]any, 0)
 
 	max_distance := GetMaxDistanceFromOptions(ctx, opts...)
 	max_results := GetMaxResultsFromOptions(ctx, opts...)
@@ -377,24 +380,37 @@ func (db *S3VectorsDatabase) SimilarRecords(ctx context.Context, req *embeddings
 
 	if similar_provider != nil {
 
-		filter["x-provider"] = map[string]string{
-			"$eq": *similar_provider,
+		f := map[string]any{
+			"x-provider": map[string]string{
+				"$eq": *similar_provider,
+			},
 		}
 
-		has_filter = true
+		filters = append(filters, f)
 	}
 
 	if len(req.Exclude) > 0 {
 
-		filter["x-depiction-id"] = map[string][]string{
-			"$nin": req.Exclude,
+		f := map[string]any{
+			"x-depiction-id": map[string][]string{
+				"$nin": req.Exclude,
+			},
 		}
 
-		has_filter = true
+		filters = append(filters, f)
 	}
 
-	if has_filter {
-		query_opts.Filter = document.NewLazyDocument(filter)
+	switch len(filters) {
+	case 0:
+		// pass
+	case 1:
+		query_opts.Filter = document.NewLazyDocument(filters[0])
+	default:
+		f := map[string]any{
+			"$and": filters,
+		}
+
+		query_opts.Filter = document.NewLazyDocument(f)
 	}
 
 	query_opts.TopK = aws.Int32(int32(*max_results))
@@ -461,6 +477,12 @@ func (db *S3VectorsDatabase) SimilarRecords(ctx context.Context, req *embeddings
 
 // ListRecords returns a paginated list of records stored in the database.
 func (db *S3VectorsDatabase) ListRecords(ctx context.Context, pg_opts pagination.Options, opts ...options.Option) ([]*embeddingsdb.Record, pagination.Results, error) {
+
+	// Here's the problem: The ListVectors API method does not provide
+	// any way to filter things...
+
+	// filters := GetAllFiltersFromOptions(ctx, opts...)
+	// args := make([]any, len(filters))
 
 	// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3vectors#NewListVectorsPaginator
 

--- a/options/dimensions.go
+++ b/options/dimensions.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"fmt"
+)
+
 type DimensionsOption struct {
 	Option
 	d int
@@ -20,4 +24,8 @@ func (o *DimensionsOption) Type() OptionType {
 
 func (o *DimensionsOption) Dimensions() int {
 	return o.d
+}
+
+func (o *DimensionsOption) String() string {
+	return fmt.Sprintf("option:dimensions=%d", o.d)
 }

--- a/options/filter.go
+++ b/options/filter.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"fmt"
+)
+
 type FilterOption struct {
 	Option
 	key   string
@@ -26,4 +30,8 @@ func (o *FilterOption) Key() string {
 
 func (o *FilterOption) Value() any {
 	return o.value
+}
+
+func (o *FilterOption) String() string {
+	return fmt.Sprintf("option:filter=%s=%v", o.key, o.value)
 }

--- a/options/max_distance.go
+++ b/options/max_distance.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"fmt"
+)
+
 type MaxDistanceOption struct {
 	Option
 	d float32
@@ -20,4 +24,8 @@ func (o *MaxDistanceOption) Type() OptionType {
 
 func (o *MaxDistanceOption) MaxDistance() float32 {
 	return o.d
+}
+
+func (o *MaxDistanceOption) String() string {
+	return fmt.Sprintf("option:max_distance=%d", o.d)
 }

--- a/options/max_results.go
+++ b/options/max_results.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"fmt"
+)
+
 type MaxResultsOption struct {
 	Option
 	d int32
@@ -20,4 +24,8 @@ func (o *MaxResultsOption) Type() OptionType {
 
 func (o *MaxResultsOption) MaxResults() int32 {
 	return o.d
+}
+
+func (o *MaxResultsOption) String() string {
+	return fmt.Sprintf("option:max_results=%d", o.d)
 }

--- a/options/option.go
+++ b/options/option.go
@@ -14,4 +14,5 @@ const (
 
 type Option interface {
 	Type() OptionType
+	String() string
 }

--- a/options/provider.go
+++ b/options/provider.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"fmt"
+)
+
 type ProviderOption struct {
 	Option
 	provider string
@@ -22,6 +26,10 @@ func (o *ProviderOption) Provider() string {
 	return o.provider
 }
 
+func (o *ProviderOption) String() string {
+	return fmt.Sprintf("option:provider=%s", o.provider)
+}
+
 type SimilarProviderOption struct {
 	Option
 	provider string
@@ -42,4 +50,8 @@ func (o *SimilarProviderOption) Type() OptionType {
 
 func (o *SimilarProviderOption) SimilarProvider() string {
 	return o.provider
+}
+
+func (o *SimilarProviderOption) String() string {
+	return fmt.Sprintf("option:similar_provider=%s", o.provider)
 }


### PR DESCRIPTION
* Bug fix: Update multi-filter syntax when fecthing similar records from s3vectors
* Bug fix: Ensure options are passed to ListRecords in www/list
* Add String() method to options.Option interface
* This release is NOT backwards compatible